### PR TITLE
reference correct master in github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,10 +6,10 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
Currently, the lints are not run automatically since I referenced the wrong master name. This commit fixes that.